### PR TITLE
修复过滤字符

### DIFF
--- a/STCObfuscator/STCObfuscator/STCObfuscator.m
+++ b/STCObfuscator/STCObfuscator/STCObfuscator.m
@@ -146,7 +146,7 @@
         method = [method stringByReplacingOccurrencesOfString:@"]" withString:@""];
         method = [method stringByReplacingOccurrencesOfString:@" " withString:@""];
         
-        NSCharacterSet *characterSet = [NSCharacterSet characterSetWithCharactersInString:@"_1234567890abcdefghijklmnopqrstuvwsyzABCDEFGHIJKLMNOPQRSTUVWXYZ"];
+        NSCharacterSet *characterSet = [NSCharacterSet characterSetWithCharactersInString:@"_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"];
 
         if ([[name stringByTrimmingCharactersInSet:characterSet] length] > 0) {
             return;


### PR DESCRIPTION
使用的时候发现静态库中某个class（含"x"字母）没被过滤，最终找到了这个位置，应该x不是s？第一次提pr，多指教哈